### PR TITLE
clear npm cache to remove package.tgz files that contain test files that are blocked by virus scanners.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:slim
 
 # Install packages
-RUN npm install -g ember-cli; npm install -g bower; apt-get update && apt-get install git -y; find / -name "cb-never*.tgz" -delete
+RUN npm install -g ember-cli; npm install -g bower; npm cache clean; apt-get update && apt-get install git -y; find / -name "cb-never*.tgz" -delete
 
 # Create Application Directory
 ENV WORKING_DIRECTORY /usr/share/unfetter-discover-ui
@@ -13,7 +13,7 @@ COPY package.json $WORKING_DIRECTORY
 COPY bower.json $WORKING_DIRECTORY
 
 # The NPM package depends on TAR package, which has a test directory with an encrypted tgz file, that gets blocked by some antivirus scanners. Removing it.
-RUN npm install; find / -name "cb-never*.tgz" -delete
+RUN npm install; npm cache clean; find / -name "cb-never*.tgz" -delete
 RUN bower install --allow-root; find / -name "cb-never*.tgz" -delete
 COPY . $WORKING_DIRECTORY
 


### PR DESCRIPTION
The file cb-never-called.1.0.1.tgz is contained in cached npm package.tgz files located in ~/.npm. adding `npm cache clean`  after `npm install` to remove these files.